### PR TITLE
Create Codeship Pro project to kick off CI builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,18 @@ Signup for each of these is free, and should only take you a few minutes if you 
     - `-p 8000` - to create a random port to prevent port collision
     - `--rm` - to remove the containers
 
-1. .
+
+## Continuous Integration with Codeship
+
+1. Test your setup locally using 'Codeship Jet CLI' (see [Getting Started docs](https://documentation.codeship.com/pro/jet-cli/usage-overview/)):
+
+        $ jet steps
+        ...
+        (step: test) success ✔
+    > Jet CLI will run through the steps file just as it would on Codeship. This is a quick way to catch errors early before committing and pushing to your repository.
+
+1. Create your own repository in any of Git Repository service (Github, Bitbucket, Gitlab) and push your code to the repo
+
+1. [Create project in Codeship](https://documentation.codeship.com/pro/quickstart/codeship-configuration/#setting-up-a-new-project)
+
+1. Push a new commit to trigger a new build on Codeship

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+bin/wait-for-postgres
+time python manage.py migrate
+
+time $1

--- a/bin/wait-for-postgres
+++ b/bin/wait-for-postgres
@@ -1,0 +1,15 @@
+#!/bin/sh
+# wait-for-postgres
+
+set -e
+
+TIMEOUT=60
+COUNT=0
+
+until pg_isready -h "postgres" -p "5432" || [ $COUNT -eq $TIMEOUT ];
+do
+  echo $COUNT
+  echo $TIMEOUT
+  sleep 1
+  COUNT=$((COUNT+1))
+done

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,0 +1,12 @@
+web_codeship_example_python:
+  build: .
+  links:
+    - postgres
+  environment:
+    DATABASE_URL: "postgres://todoapp@postgres/todos"
+  cached: true
+postgres:
+  image: postgres:9.6.2-alpine
+  environment:
+    POSTGRES_USER: todoapp
+    POSTGRES_DB: todos

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,0 +1,3 @@
+- name: test
+  service: web_codeship_example_python
+  command: bin/ci "python manage.py test" # you only need to change the command here


### PR DESCRIPTION
STEPS:
1. Create the [Codeship services definition file](https://documentation.codeship.com/pro/builds-and-configuration/services/)
1. Create the [Codeship steps file](https://documentation.codeship.com/pro/builds-and-configuration/steps/)
1. Create bash scripts (`bin/wait-for-postgres`, `bin/ci`) - to check that the db is available before starting the migration.
1. Run `$ chmod +x bin/**` to mark scripts as executable files
1. Run `$ jet steps` to test your setup locally using "Jet CLI"
1. [Create project in Codeship](https://documentation.codeship.com/pro/quickstart/codeship-configuration/#setting-up-a-new-project)
1. Push a new commit to trigger a new build on Codeship